### PR TITLE
Implementation of Cell Copy/Paste Events Using Clipboard Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,6 @@ A number defining the height of summary rows.
 
 ###### `onFill?: Maybe<(event: FillEvent<R>) => R>`
 
-###### `onCopy?: Maybe<(event: CopyEvent<R>) => void>`
-
-###### `onPaste?: Maybe<(event: PasteEvent<R>) => R>`
-
 ###### `onCellClick?: Maybe<(args: CellClickArgs<R, SR>, event: CellMouseEvent) => void>`
 
 ###### `onCellDoubleClick?: Maybe<(args: CellClickArgs<R, SR>, event: CellMouseEvent) => void>`
@@ -197,6 +193,10 @@ A number defining the height of summary rows.
 ###### `onCellContextMenu?: Maybe<(args: CellClickArgs<R, SR>, event: CellMouseEvent) => void>`
 
 ###### `onCellKeyDown?: Maybe<(args: CellKeyDownArgs<R, SR>, event: CellKeyboardEvent) => void>`
+
+###### `onCopy?: Maybe<(args: CellCopyArgs<R>, event: CellClipboardEvent) => void>`
+
+###### `onPaste?: Maybe<(args: CellPasteArgs<R>, event: CellClipboardEvent) => R>`
 
 ###### `onSelectedCellChange?: Maybe<(args: CellSelectArgs<R, SR>) => void>;`
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,8 @@ export type CellMouseEvent = CellEvent<React.MouseEvent<HTMLDivElement>>;
 
 export type CellKeyboardEvent = CellEvent<React.KeyboardEvent<HTMLDivElement>>;
 
+export type CellClipboardEvent = CellEvent<React.ClipboardEvent<HTMLDivElement>>;
+
 export interface CellClickArgs<TRow, TSummaryRow = unknown> {
   row: TRow;
   column: CalculatedColumn<TRow, TSummaryRow>;
@@ -192,6 +194,18 @@ export interface EditCellKeyDownArgs<TRow, TSummaryRow = unknown> {
 export type CellKeyDownArgs<TRow, TSummaryRow = unknown> =
   | SelectCellKeyDownArgs<TRow, TSummaryRow>
   | EditCellKeyDownArgs<TRow, TSummaryRow>;
+
+export interface CellCopyArgs<TRow> {
+  sourceColumnKey: string;
+  sourceRow: TRow;
+}
+
+export interface CellPasteArgs<TRow> {
+  sourceColumnKey: string;
+  sourceRow: TRow;
+  targetColumnKey: string;
+  targetRow: TRow;
+}
 
 export interface CellSelectArgs<TRow, TSummaryRow = unknown> {
   rowIdx: number;
@@ -238,18 +252,6 @@ export type SelectRowEvent<TRow> =
 export interface FillEvent<TRow> {
   columnKey: string;
   sourceRow: TRow;
-  targetRow: TRow;
-}
-
-export interface CopyEvent<TRow> {
-  sourceColumnKey: string;
-  sourceRow: TRow;
-}
-
-export interface PasteEvent<TRow> {
-  sourceColumnKey: string;
-  sourceRow: TRow;
-  targetColumnKey: string;
   targetRow: TRow;
 }
 

--- a/test/copyPaste.test.tsx
+++ b/test/copyPaste.test.tsx
@@ -100,7 +100,7 @@ test('should allow copy if only onCopy is specified', async () => {
   await userEvent.click(getCellsAtRowIndex(0)[0]);
   copySelectedCell();
   expect(getSelectedCell()).toHaveClass(copyCellClassName);
-  expect(onCopySpy).toHaveBeenCalledWith({
+  expect(onCopySpy.mock.calls[0][0]).toStrictEqual({
     sourceRow: initialRows[0],
     sourceColumnKey: 'col'
   });
@@ -127,7 +127,7 @@ test('should allow copy/paste if both onPaste & onCopy is specified', async () =
   await userEvent.click(getCellsAtRowIndex(0)[0]);
   copySelectedCell();
   expect(getSelectedCell()).toHaveClass(copyCellClassName);
-  expect(onCopySpy).toHaveBeenCalledWith({
+  expect(onCopySpy.mock.calls[0][0]).toStrictEqual({
     sourceRow: initialRows[0],
     sourceColumnKey: 'col'
   });

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -68,19 +68,12 @@ export function validateCellPosition(columnIdx: number, rowIdx: number) {
 }
 
 export function copySelectedCell() {
-  // eslint-disable-next-line testing-library/prefer-user-event
-  fireEvent.keyDown(document.activeElement!, {
-    keyCode: '67',
-    ctrlKey: true
-  });
+  fireEvent.copy(document.activeElement!);
 }
 
 export function pasteSelectedCell() {
   // eslint-disable-next-line testing-library/prefer-user-event
-  fireEvent.keyDown(document.activeElement!, {
-    keyCode: '86',
-    ctrlKey: true
-  });
+  fireEvent.paste(document.activeElement!);
 }
 
 export async function scrollGrid({

--- a/website/demos/AllFeatures.tsx
+++ b/website/demos/AllFeatures.tsx
@@ -4,6 +4,7 @@ import { css } from '@linaria/core';
 
 import DataGrid, { SelectColumn, textEditor } from '../../src';
 import type { Column, CopyEvent, FillEvent, PasteEvent } from '../../src';
+import { type CellClipboardEvent } from '../../src/types';
 import { renderAvatar, renderDropdown } from './renderers';
 import type { Props } from './types';
 
@@ -189,10 +190,12 @@ export default function AllFeatures({ direction }: Props) {
     return { ...targetRow, [targetColumnKey]: sourceRow[sourceColumnKey as keyof Row] };
   }
 
-  function handleCopy({ sourceRow, sourceColumnKey }: CopyEvent<Row>): void {
-    if (window.isSecureContext) {
-      navigator.clipboard.writeText(sourceRow[sourceColumnKey as keyof Row]);
-    }
+  function handleCopy(
+    { sourceRow, sourceColumnKey }: CopyEvent<Row>,
+    event: CellClipboardEvent
+  ): void {
+    event.preventDefault();
+    event.clipboardData.setData('text/plain', sourceRow[sourceColumnKey as keyof Row]);
   }
 
   return (


### PR DESCRIPTION
Hi, maintainers!
This PR implements onCopy/onPaste events as Cell Clipboard Events not parts of keydown events.

Previously, copy and paste events were implemented as part of keydown events.
This could be slightly confusing for developers. For example, `preventGridDefault` method cannot be used to prevent the default onCopy behavior.
With this PR, developers can now utilize Clipboard events, allowing for development with natural APIs without the need to use `navigator.clipboard.writeText`.

Additionally, by separating the processes that were aggregated under keydown events into onCopy and onPaste events, it is possible to reduce the complexity of the implementation.

### Related PRs
- [External copy paste handlers](https://github.com/adazzle/react-data-grid/pull/2981)
- [Include KeyboardEvent to onCopy and onPaste callbacks](https://github.com/adazzle/react-data-grid/pull/3270)